### PR TITLE
fix(security): empêche l'affichage des données d'un autre compte et d…

### DIFF
--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -23,6 +23,7 @@ import * as SplashScreen from "expo-splash-screen";
 import React, { useEffect, useRef, useState } from "react";
 import { Platform } from "react-native";
 import { TamaguiProvider } from "tamagui";
+import { AuthCacheSync } from "@/components/auth-cache-sync";
 import { NoticeProvider, NoticeViewport } from "@/components/ui/notice";
 import { setAndroidNavigationBar } from "@/lib/android-navigation-bar";
 import { authClient } from "@/lib/auth-client";
@@ -131,6 +132,7 @@ export default function RootLayout() {
 					maxAge: 24 * 60 * 60 * 1000,
 				}}
 			>
+				<AuthCacheSync />
 				<ThemeProvider value={isDarkColorScheme ? DARK_THEME : LIGHT_THEME}>
 					<TamaguiProvider
 						config={tamaguiConfig}

--- a/apps/native/components/auth-cache-sync.tsx
+++ b/apps/native/components/auth-cache-sync.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from "react";
+import { authClient } from "@/lib/auth-client";
+import { queryClient } from "@/utils/trpc";
+
+/**
+ * Miroir natif de l'AuthCacheSync web : les clés de requêtes tRPC ne sont pas
+ * scopées par utilisateur et le cache React Query est persisté sur disque
+ * (24 h). On vide donc tout le cache dès que l'identité connectée change,
+ * pour ne jamais afficher les données d'un autre compte.
+ */
+export function AuthCacheSync() {
+	const { data: session, isPending } = authClient.useSession();
+	const previousUserIdRef = useRef<string | null | undefined>(undefined);
+
+	useEffect(() => {
+		if (isPending) {
+			return;
+		}
+
+		const currentUserId = session?.user?.id ?? null;
+		const previousUserId = previousUserIdRef.current;
+
+		if (previousUserId === undefined) {
+			previousUserIdRef.current = currentUserId;
+			return;
+		}
+
+		if (previousUserId !== currentUserId) {
+			queryClient.clear();
+		}
+
+		previousUserIdRef.current = currentUserId;
+	}, [isPending, session?.user?.id]);
+
+	return null;
+}

--- a/apps/native/components/google-auth-button.tsx
+++ b/apps/native/components/google-auth-button.tsx
@@ -65,7 +65,9 @@ export function GoogleAuthButton({ action }: GoogleAuthButtonProps) {
 						setIsLoading(false);
 					},
 					onSuccess: () => {
-						queryClient.invalidateQueries();
+						// Vide le cache (mémoire + disque) pour ne jamais montrer
+						// les données d'un compte précédemment connecté.
+						queryClient.clear();
 					},
 					onFinished: () => {
 						setIsLoading(false);

--- a/apps/native/components/login/sign-in.tsx
+++ b/apps/native/components/login/sign-in.tsx
@@ -24,7 +24,9 @@ export function SignIn({
 	const { showNotice } = useNotice();
 	const { form, isLoading } = useSignInForm({
 		onSuccess: async () => {
-			void queryClient.refetchQueries();
+			// Vide le cache (mémoire + disque) pour ne jamais montrer les
+			// données d'un compte précédemment connecté sur cet appareil.
+			queryClient.clear();
 			router.replace("/(drawer)/profile");
 			showNotice({
 				title: "Connexion reussie",

--- a/apps/native/lib/use-sign-out.ts
+++ b/apps/native/lib/use-sign-out.ts
@@ -10,7 +10,10 @@ export function useSignOut() {
 		setIsSigningOut(true);
 		try {
 			await authClient.signOut();
-			await queryClient.invalidateQueries();
+			// clear() et non invalidateQueries() : un refetch sans session échoue
+			// mais laisserait les données de l'ancien compte en cache (et sur
+			// disque via le persister).
+			queryClient.clear();
 		} finally {
 			setIsSigningOut(false);
 		}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -6,8 +6,10 @@ import "server-only";
 
 import { expo } from "@better-auth/expo";
 import { db } from "@rythmons/db";
+import { signUpRoleValues, userRoleValues } from "@rythmons/validation";
 import { type BetterAuthOptions, betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
+import { APIError } from "better-auth/api";
 import { saveDevVerificationPreview } from "./dev-email-preview";
 import { sendMail } from "./email/mailer";
 import { resetPasswordTemplate, verifyEmailTemplate } from "./email/templates";
@@ -83,6 +85,14 @@ function getRequestOrigin(request?: Request) {
 	return null;
 }
 
+// `additionalFields.role` accepte n'importe quelle chaîne via un appel direct
+// à l'API : on impose côté serveur les mêmes valeurs que le client.
+function assertValidRole(role: unknown, allowed: readonly string[]) {
+	if (role != null && !allowed.includes(role as string)) {
+		throw new APIError("BAD_REQUEST", { message: "Rôle invalide." });
+	}
+}
+
 export const auth = betterAuth<BetterAuthOptions>({
 	database: prismaAdapter(db, {
 		provider: "postgresql",
@@ -103,7 +113,12 @@ export const auth = betterAuth<BetterAuthOptions>({
 
 		try {
 			const { hostname } = new URL(requestOrigin);
-			const isVercelPreviewHost = hostname.endsWith(".vercel.app");
+			// Restreint aux previews de CE projet : faire confiance à tout
+			// *.vercel.app reviendrait à accepter le site Vercel de n'importe qui
+			// comme origine de confiance (affaiblissement CSRF).
+			const isVercelPreviewHost = hostname.endsWith(
+				"-rythmons-projects.vercel.app",
+			);
 			const isLocalhost = hostname === "localhost" || hostname === "127.0.0.1";
 			if (
 				(isVercelPreviewHost || isLocalhost) &&
@@ -185,6 +200,24 @@ export const auth = betterAuth<BetterAuthOptions>({
 		},
 	},
 
+	databaseHooks: {
+		user: {
+			create: {
+				before: async (user) => {
+					assertValidRole((user as { role?: unknown }).role, signUpRoleValues);
+					return { data: user };
+				},
+			},
+			update: {
+				before: async (user) => {
+					if ("role" in user) {
+						assertValidRole((user as { role?: unknown }).role, userRoleValues);
+					}
+					return { data: user };
+				},
+			},
+		},
+	},
 	advanced: {
 		defaultCookieAttributes: {
 			sameSite: "lax", // First-party cookies for same-domain setup


### PR DESCRIPTION
…urcit l'auth

- Natif : ajoute AuthCacheSync (miroir du composant web) qui vide le cache React Query — persisté sur disque pendant 24 h — dès que l'identité connectée change, et remplace invalidateQueries/refetchQueries par queryClient.clear() au signOut, au sign-in email et au sign-in Google. invalidateQueries laissait les données de l'ancien compte en cache quand le refetch échouait sans session, et refetchQueries affichait les données du compte précédent pendant le rechargement.
- Auth : restreint les origines de confiance dynamiques aux previews du projet (-rythmons-projects.vercel.app) au lieu de tout *.vercel.app.
- Auth : valide le champ `role` côté serveur via databaseHooks (ARTIST/ORGANIZER à la création, valeurs connues à la mise à jour) — additionalFields acceptait sinon n'importe quelle chaîne par appel direct à l'API.